### PR TITLE
Fix missing `question` command

### DIFF
--- a/chato-notes.sty
+++ b/chato-notes.sty
@@ -123,9 +123,11 @@
 
 }
 \DeclareOption{hide}{
+	\newcommand{\question}[2][]{}
 	\newcommand{\mynote}[2][]{}
 	\newcommand{\todo}[2][]{}
 	\newcommand{\reply}[2][]{}
+	\newcommand{\iquestion}[1][]{}
 	\newcommand{\inote}[1][]{}
 	\newcommand{\itodo}[1][]{}
 	\newcommand{\ireply}[1][]{}


### PR DESCRIPTION
When the package is used with the `hide` option, the `question` and `iquestion` commands are not defined. This commit adds the appropriate declarations.
